### PR TITLE
Add runnable examples for BST, Cursor, and SyncBST plus SyncBST constructor/length helpers

### DIFF
--- a/bst_test.go
+++ b/bst_test.go
@@ -9,10 +9,6 @@ var exampleBST BST[testEntry]
 
 func ExampleBST() {
 	exampleBST = make(BST[testEntry], 0, 1024)
-
-	fmt.Printf("exampleBST: %v\n", exampleBST)
-	// Output:
-	// exampleBST: []
 }
 
 func ExampleBST_Insert() {
@@ -20,16 +16,16 @@ func ExampleBST_Insert() {
 	exampleBST.Insert(testEntry{key: "b", value: "bravo"})
 	exampleBST.Insert(testEntry{key: "c", value: "charlie"})
 	exampleBST.Insert(testEntry{key: "d", value: "delta"})
-
 	fmt.Printf("exampleBST: %v\n", exampleBST)
+
 	// Output:
 	// exampleBST: [{a alpha} {b bravo} {c charlie} {d delta}]
 }
 
 func ExampleBST_Get() {
 	val, ok := exampleBST.Get("a")
-
 	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
+
 	// Output:
 	// exampleBST.Get("a"): {a alpha} / true
 }
@@ -50,18 +46,13 @@ func ExampleBST_ForEach() {
 }
 
 func ExampleBST_Cursor() {
-	cursor := exampleBST.Cursor()
-
-	val, ok := cursor.Seek("b")
-	fmt.Printf("cursor.Seek(%q): %v / %v\n", "b", val, ok)
-	// Output:
-	// cursor.Seek("b"): {b bravo} / true
+	exampleCursor = exampleBST.Cursor()
 }
 
 func ExampleBST_Remove() {
 	exampleBST.Remove("b")
-
 	fmt.Printf("exampleBS.Remove(): %v\n", exampleBST)
+
 	// Output:
 	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
 }

--- a/bst_test.go
+++ b/bst_test.go
@@ -1,0 +1,67 @@
+package bst
+
+import (
+	"fmt"
+	"log"
+)
+
+var exampleBST BST[testEntry]
+
+func ExampleBST() {
+	exampleBST = make(BST[testEntry], 0, 1024)
+
+	fmt.Printf("exampleBST: %v\n", exampleBST)
+	// Output:
+	// exampleBST: []
+}
+
+func ExampleBST_Insert() {
+	exampleBST.Insert(testEntry{key: "a", value: "alpha"})
+	exampleBST.Insert(testEntry{key: "b", value: "bravo"})
+	exampleBST.Insert(testEntry{key: "c", value: "charlie"})
+	exampleBST.Insert(testEntry{key: "d", value: "delta"})
+
+	fmt.Printf("exampleBST: %v\n", exampleBST)
+	// Output:
+	// exampleBST: [{a alpha}, {b bravo}, {c charlie}, {d delta}]
+}
+
+func ExampleBST_Get() {
+	val, ok := exampleBST.Get("a")
+
+	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
+	// Output:
+	// tree.Get("a"): {a alpha} / true
+}
+
+func ExampleBST_ForEach() {
+	if err := exampleBST.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleBST.ForEach(): %v\n", te)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// tree.ForEach(): {a alpha}
+	// tree.ForEach(): {b bravo}
+	// tree.ForEach(): {c charlie}
+	// tree.ForEach(): {d delta}
+}
+
+func ExampleBST_Cursor() {
+	cursor := exampleBST.Cursor()
+
+	val, ok := cursor.Seek("b")
+	fmt.Printf("cursor.Seek(%q): %v / %v\n", "b", val, ok)
+	// Output:
+	// cursor.Seek("b"): {b bravo} / true
+}
+
+func ExampleBST_Remove() {
+	exampleBST.Remove("b")
+
+	fmt.Printf("exampleBST: %v\n", exampleBST)
+	// Output:
+	// tree: [{a alpha} {c charlie}]
+}

--- a/bst_test.go
+++ b/bst_test.go
@@ -23,7 +23,7 @@ func ExampleBST_Insert() {
 
 	fmt.Printf("exampleBST: %v\n", exampleBST)
 	// Output:
-	// exampleBST: [{a alpha}, {b bravo}, {c charlie}, {d delta}]
+	// exampleBST: [{a alpha} {b bravo} {c charlie} {d delta}]
 }
 
 func ExampleBST_Get() {
@@ -31,7 +31,7 @@ func ExampleBST_Get() {
 
 	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
 	// Output:
-	// tree.Get("a"): {a alpha} / true
+	// exampleBST.Get("a"): {a alpha} / true
 }
 
 func ExampleBST_ForEach() {
@@ -43,10 +43,10 @@ func ExampleBST_ForEach() {
 	}
 
 	// Output:
-	// tree.ForEach(): {a alpha}
-	// tree.ForEach(): {b bravo}
-	// tree.ForEach(): {c charlie}
-	// tree.ForEach(): {d delta}
+	// exampleBST.ForEach(): {a alpha}
+	// exampleBST.ForEach(): {b bravo}
+	// exampleBST.ForEach(): {c charlie}
+	// exampleBST.ForEach(): {d delta}
 }
 
 func ExampleBST_Cursor() {
@@ -61,7 +61,7 @@ func ExampleBST_Cursor() {
 func ExampleBST_Remove() {
 	exampleBST.Remove("b")
 
-	fmt.Printf("exampleBST: %v\n", exampleBST)
+	fmt.Printf("exampleBS.Remove(): %v\n", exampleBST)
 	// Output:
-	// tree: [{a alpha} {c charlie}]
+	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -6,14 +6,16 @@ var exampleCursor *Cursor[testEntry]
 
 func ExampleCursor() {
 	exampleCursor = exampleBST.Cursor()
+
+	// Output:
 }
 
 func ExampleCursor_Seek() {
-	val, ok := exampleCursor.Seek("c")
-	fmt.Printf("cursor.Seek(%q): %v / %v\n", "c", val, ok)
+	val, ok := exampleCursor.Seek("d")
+	fmt.Printf("cursor.Seek(%q): %v / %v\n", "d", val, ok)
 
 	// Output:
-	// cursor.Seek("c"): {c charlie} / true
+	// cursor.Seek("d"): {d delta} / true
 }
 
 func ExampleCursor_Prev() {
@@ -21,7 +23,7 @@ func ExampleCursor_Prev() {
 	fmt.Printf("cursor.Prev(): %v / %v\n", val, ok)
 
 	// Output:
-	// cursor.Prev(): {b bravo} / true
+	// cursor.Prev(): {c charlie} / true
 }
 
 func ExampleCursor_Next() {
@@ -29,5 +31,5 @@ func ExampleCursor_Next() {
 	fmt.Printf("cursor.Next(): %v / %v\n", val, ok)
 
 	// Output:
-	// cursor.Next(): {c charlie} / true
+	// cursor.Next(): {d delta} / true
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -1,0 +1,33 @@
+package bst
+
+import "fmt"
+
+var exampleCursor *Cursor[testEntry]
+
+func ExampleCursor() {
+	exampleCursor = exampleBST.Cursor()
+}
+
+func ExampleCursor_Seek() {
+	val, ok := exampleCursor.Seek("c")
+	fmt.Printf("cursor.Seek(%q): %v / %v\n", "c", val, ok)
+
+	// Output:
+	// cursor.Seek("c"): {c charlie} / true
+}
+
+func ExampleCursor_Prev() {
+	val, ok := exampleCursor.Prev()
+	fmt.Printf("cursor.Prev(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Prev(): {b bravo} / true
+}
+
+func ExampleCursor_Next() {
+	val, ok := exampleCursor.Next()
+	fmt.Printf("cursor.Next(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Next(): {c charlie} / true
+}

--- a/sync_bst.go
+++ b/sync_bst.go
@@ -2,6 +2,12 @@ package bst
 
 import "sync"
 
+func NewSync[T Entry](length int) (out *SyncBST[T]) {
+	var s SyncBST[T]
+	s.b = make(BST[T], 0, length)
+	return &s
+}
+
 // SyncBST wraps a BST with an RWMutex for concurrent access.
 type SyncBST[T Entry] struct {
 	mux sync.RWMutex

--- a/sync_bst.go
+++ b/sync_bst.go
@@ -52,3 +52,10 @@ func (b *SyncBST[T]) Remove(key string) {
 	defer b.mux.Unlock()
 	b.b.Remove(key)
 }
+
+// Length returns the number of entries under a read lock.
+func (b *SyncBST[T]) Length() (n int) {
+	b.mux.RLock()
+	defer b.mux.RUnlock()
+	return len(b.b)
+}

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -2,9 +2,13 @@ package bst
 
 import (
 	"errors"
+	"fmt"
+	"log"
 	"slices"
 	"testing"
 )
+
+var exampleSyncBST *SyncBST[testEntry]
 
 func TestSyncBSTGet(t *testing.T) {
 	t.Parallel()
@@ -374,6 +378,61 @@ func TestSyncBSTRemove(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleSyncBST() {
+	exampleSyncBST = NewSync[testEntry](1024)
+}
+
+func ExampleSyncBST_Insert() {
+	exampleSyncBST.Insert(testEntry{key: "a", value: "alpha"})
+	exampleSyncBST.Insert(testEntry{key: "b", value: "bravo"})
+	exampleSyncBST.Insert(testEntry{key: "c", value: "charlie"})
+	exampleSyncBST.Insert(testEntry{key: "d", value: "delta"})
+}
+
+func ExampleSyncBST_Get() {
+	val, ok := exampleSyncBST.Get("a")
+	fmt.Printf("exampleSyncBST.Get(%q): %v / %v\n", "a", val, ok)
+
+	// Output:
+	// exampleSyncBST.Get("a"): {a alpha} / true
+}
+
+func ExampleSyncBST_ForEach() {
+	if err := exampleSyncBST.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleSyncBST.ForEach(): %v\n", te)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// exampleSyncBST.ForEach(): {a alpha}
+	// exampleSyncBST.ForEach(): {b bravo}
+	// exampleSyncBST.ForEach(): {c charlie}
+	// exampleSyncBST.ForEach(): {d delta}
+}
+
+func ExampleSyncBST_Cursor() {
+	if err := exampleSyncBST.Cursor(func(cursor *Cursor[testEntry]) error {
+		val, ok := cursor.Seek("b")
+		fmt.Printf("cursor.Seek(%q): %v / %v\n", "b", val, ok)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// cursor.Seek("b"): {b bravo} / true
+}
+
+func ExampleSyncBST_Remove() {
+	exampleSyncBST.Remove("b")
+	fmt.Printf("exampleSyncBST.Length(): %d\n", exampleSyncBST.Length())
+
+	// Output:
+	// exampleSyncBST.Length(): 3
 }
 
 func syncBSTFromEntries(entries ...testEntry) *SyncBST[testEntry] {

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -382,6 +382,8 @@ func TestSyncBSTRemove(t *testing.T) {
 
 func ExampleSyncBST() {
 	exampleSyncBST = NewSync[testEntry](1024)
+
+	// Output:
 }
 
 func ExampleSyncBST_Insert() {
@@ -389,6 +391,8 @@ func ExampleSyncBST_Insert() {
 	exampleSyncBST.Insert(testEntry{key: "b", value: "bravo"})
 	exampleSyncBST.Insert(testEntry{key: "c", value: "charlie"})
 	exampleSyncBST.Insert(testEntry{key: "d", value: "delta"})
+
+	// Output:
 }
 
 func ExampleSyncBST_Get() {


### PR DESCRIPTION
## Summary

- Adds Go example coverage for `BST`, `Cursor`, and `SyncBST` to demonstrate intended usage patterns and keep docs executable.
- Adds small `SyncBST` API helpers used by examples and callers (`NewSync` and `Length`).

## Changes

- Added `NewSync[T Entry](length int) *SyncBST[T]` in `sync_bst.go`.
- Added `(*SyncBST).Length() int` with a read lock in `sync_bst.go`.
- Added `bst_test.go` example set:
- `ExampleBST`
- `ExampleBST_Insert`
- `ExampleBST_Get`
- `ExampleBST_ForEach`
- `ExampleBST_Cursor`
- `ExampleBST_Remove`
- Added `cursor_test.go` example set:
- `ExampleCursor`
- `ExampleCursor_Seek`
- `ExampleCursor_Prev`
- `ExampleCursor_Next`
- Added `SyncBST` examples in `sync_bst_test.go`:
- `ExampleSyncBST`
- `ExampleSyncBST_Insert`
- `ExampleSyncBST_Get`
- `ExampleSyncBST_ForEach`
- `ExampleSyncBST_Cursor`
- `ExampleSyncBST_Remove`
