### PR TITLE
Make README examples more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,7 @@ then a sorted structure like `bst` can be a better fit.
 
 ## Examples
 
-Below are quick API examples.
-
-### Entry
-```go
-type userEntry struct {
-	id   int
-	name string
-}
-
-func (u userEntry) Key() string {
-	return u.name
-}
-```
-
-### BST
+### Initialize BST
 ```go
 func ExampleBST() {
 	users := make(bst.BST[userEntry], 0, 8)


### PR DESCRIPTION
## Summary

- Simplifies the README examples section by removing the standalone `Entry` type example and keeping a single, focused BST initialization example.

## Changes

- Removed the "Below are quick API examples." lead-in text.
- Removed the `### Entry` subsection and its `userEntry`/`Key()` snippet.
- Renamed `### BST` to `### Initialize BST`.
- Kept the existing BST example code intact.

## Testing

- N/A
