### PR TITLE
Add Cursor First/Last docs and consolidate cursor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,28 @@ func ExampleCursor_Next() {
 }
 ```
 
+### Cursor.First
+```go
+func ExampleCursor_First() {
+	val, ok := exampleCursor.First()
+	fmt.Printf("cursor.First(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.First(): {a alpha} / true
+}
+```
+
+### Cursor.Last
+```go
+func ExampleCursor_Last() {
+	val, ok := exampleCursor.Last()
+	fmt.Printf("cursor.Last(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Last(): {d delta} / true
+}
+```
+
 ### NewSync
 ```go
 func ExampleNewSync() {

--- a/cursor.go
+++ b/cursor.go
@@ -42,3 +42,23 @@ func (c *Cursor[T]) Next() (val T, ok bool) {
 
 	return c.b[c.index], true
 }
+
+func (c *Cursor[T]) First() (val T, ok bool) {
+	if len(c.b) == 0 {
+		return val, false
+	}
+
+	c.index = 0
+
+	return c.b[c.index], true
+}
+
+func (c *Cursor[T]) Last() (val T, ok bool) {
+	if len(c.b) == 0 {
+		return val, false
+	}
+
+	c.index = len(c.b) - 1
+
+	return c.b[c.index], true
+}

--- a/cursor.go
+++ b/cursor.go
@@ -43,6 +43,7 @@ func (c *Cursor[T]) Next() (val T, ok bool) {
 	return c.b[c.index], true
 }
 
+// First moves the cursor to the first entry.
 func (c *Cursor[T]) First() (val T, ok bool) {
 	if len(c.b) == 0 {
 		return val, false
@@ -53,6 +54,7 @@ func (c *Cursor[T]) First() (val T, ok bool) {
 	return c.b[c.index], true
 }
 
+// Last moves the cursor to the last entry.
 func (c *Cursor[T]) Last() (val T, ok bool) {
 	if len(c.b) == 0 {
 		return val, false

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -298,6 +298,22 @@ func ExampleCursor_Next() {
 	// cursor.Next(): {d delta} / true
 }
 
+func ExampleCursor_First() {
+	val, ok := exampleCursor.First()
+	fmt.Printf("cursor.First(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.First(): {a alpha} / true
+}
+
+func ExampleCursor_Last() {
+	val, ok := exampleCursor.Last()
+	fmt.Printf("cursor.Last(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Last(): {d delta} / true
+}
+
 func cursorBSTFromEntries(entries ...testEntry) (tree BST[testEntry]) {
 	tree = make(BST[testEntry], 0, len(entries))
 	for _, entry := range entries {

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -7,6 +7,165 @@ import (
 
 var exampleCursor *Cursor[testEntry]
 
+func TestCursorSeek(t *testing.T) {
+	t.Parallel()
+
+	tree := cursorBSTFromEntries(
+		testEntry{key: "a", value: "alpha"},
+		testEntry{key: "c", value: "charlie"},
+		testEntry{key: "e", value: "echo"},
+	)
+
+	tests := []struct {
+		name   string
+		key    string
+		want   testEntry
+		wantOK bool
+	}{
+		{
+			name:   "hit",
+			key:    "c",
+			want:   testEntry{key: "c", value: "charlie"},
+			wantOK: true,
+		},
+		{
+			name:   "miss between entries",
+			key:    "d",
+			wantOK: false,
+		},
+		{
+			name:   "miss after last entry",
+			key:    "z",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cursor := tree.Cursor()
+			got, gotOK := cursor.Seek(tt.key)
+			if gotOK != tt.wantOK {
+				t.Fatalf("Seek(%q) ok = %v, want %v", tt.key, gotOK, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("Seek(%q) = %#v, want %#v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorPrev(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		key    string
+		want   testEntry
+		wantOK bool
+		seekOK bool
+	}{
+		{
+			name:   "returns previous entry",
+			key:    "c",
+			want:   testEntry{key: "a", value: "alpha"},
+			wantOK: true,
+			seekOK: true,
+		},
+		{
+			name:   "at beginning returns false",
+			key:    "a",
+			wantOK: false,
+			seekOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := cursorBSTFromEntries(
+				testEntry{key: "a", value: "alpha"},
+				testEntry{key: "c", value: "charlie"},
+				testEntry{key: "e", value: "echo"},
+			)
+
+			cursor := tree.Cursor()
+			_, seekOK := cursor.Seek(tt.key)
+			if seekOK != tt.seekOK {
+				t.Fatalf("Seek(%q) ok = %v, want %v", tt.key, seekOK, tt.seekOK)
+			}
+
+			got, gotOK := cursor.Prev()
+			if gotOK != tt.wantOK {
+				t.Fatalf("Prev() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("Prev() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		key    string
+		want   testEntry
+		wantOK bool
+		seekOK bool
+	}{
+		{
+			name:   "returns next entry",
+			key:    "c",
+			want:   testEntry{key: "e", value: "echo"},
+			wantOK: true,
+			seekOK: true,
+		},
+		{
+			name:   "at end returns false",
+			key:    "e",
+			wantOK: false,
+			seekOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := cursorBSTFromEntries(
+				testEntry{key: "a", value: "alpha"},
+				testEntry{key: "c", value: "charlie"},
+				testEntry{key: "e", value: "echo"},
+			)
+
+			cursor := tree.Cursor()
+			_, seekOK := cursor.Seek(tt.key)
+			if seekOK != tt.seekOK {
+				t.Fatalf("Seek(%q) ok = %v, want %v", tt.key, seekOK, tt.seekOK)
+			}
+
+			got, gotOK := cursor.Next()
+			if gotOK != tt.wantOK {
+				t.Fatalf("Next() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("Next() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCursorFirst(t *testing.T) {
 	t.Parallel()
 

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -1,8 +1,113 @@
 package bst
 
-import "fmt"
+import (
+	"fmt"
+	"testing"
+)
 
 var exampleCursor *Cursor[testEntry]
+
+func TestCursorFirst(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tree    BST[testEntry]
+		want    testEntry
+		wantOK  bool
+		wantKey string
+	}{
+		{
+			name:   "empty tree",
+			tree:   cursorBSTFromEntries(),
+			wantOK: false,
+		},
+		{
+			name:    "returns first entry and positions cursor at beginning",
+			tree:    cursorBSTFromEntries(testEntry{key: "a", value: "alpha"}, testEntry{key: "c", value: "charlie"}, testEntry{key: "e", value: "echo"}),
+			want:    testEntry{key: "a", value: "alpha"},
+			wantOK:  true,
+			wantKey: "c",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cursor := tt.tree.Cursor()
+			got, gotOK := cursor.First()
+			if gotOK != tt.wantOK {
+				t.Fatalf("First() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("First() = %#v, want %#v", got, tt.want)
+			}
+
+			if !tt.wantOK {
+				return
+			}
+
+			next, nextOK := cursor.Next()
+			if !nextOK || next.key != tt.wantKey {
+				t.Fatalf("Next() = (%#v, %v), want key %q and ok=true", next, nextOK, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestCursorLast(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		tree    BST[testEntry]
+		want    testEntry
+		wantOK  bool
+		wantKey string
+	}{
+		{
+			name:   "empty tree",
+			tree:   cursorBSTFromEntries(),
+			wantOK: false,
+		},
+		{
+			name:    "returns last entry and positions cursor at end",
+			tree:    cursorBSTFromEntries(testEntry{key: "a", value: "alpha"}, testEntry{key: "c", value: "charlie"}, testEntry{key: "e", value: "echo"}),
+			want:    testEntry{key: "e", value: "echo"},
+			wantOK:  true,
+			wantKey: "c",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cursor := tt.tree.Cursor()
+			got, gotOK := cursor.Last()
+			if gotOK != tt.wantOK {
+				t.Fatalf("Last() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("Last() = %#v, want %#v", got, tt.want)
+			}
+
+			if !tt.wantOK {
+				return
+			}
+
+			prev, prevOK := cursor.Prev()
+			if !prevOK || prev.key != tt.wantKey {
+				t.Fatalf("Prev() = (%#v, %v), want key %q and ok=true", prev, prevOK, tt.wantKey)
+			}
+		})
+	}
+}
 
 func ExampleCursor() {
 	exampleCursor = exampleBST.Cursor()
@@ -32,4 +137,13 @@ func ExampleCursor_Next() {
 
 	// Output:
 	// cursor.Next(): {d delta} / true
+}
+
+func cursorBSTFromEntries(entries ...testEntry) (tree BST[testEntry]) {
+	tree = make(BST[testEntry], 0, len(entries))
+	for _, entry := range entries {
+		tree.Insert(entry)
+	}
+
+	return tree
 }

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -129,96 +129,15 @@ func TestSyncBSTCursor(t *testing.T) {
 		testEntry{key: "e", value: "echo"},
 	)
 
-	tests := []struct {
-		name string
-		run  func(*testing.T, *SyncBST[testEntry])
-	}{
-		{
-			name: "seek existing and navigate neighbors",
-			run: func(t *testing.T, tree *SyncBST[testEntry]) {
-				err := tree.Cursor(func(c *Cursor[testEntry]) error {
-					got, ok := c.Seek("c")
-					if !ok || got.key != "c" {
-						t.Fatalf("Seek(%q) = (%#v, %v), want key %q and ok=true", "c", got, ok, "c")
-					}
+	err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
+		if cursor == nil {
+			t.Fatal("Cursor() passed nil cursor")
+		}
 
-					prev, ok := c.Prev()
-					if !ok || prev.key != "a" {
-						t.Fatalf("Prev() = (%#v, %v), want key %q and ok=true", prev, ok, "a")
-					}
-
-					next, ok := c.Next()
-					if !ok || next.key != "c" {
-						t.Fatalf("Next() = (%#v, %v), want key %q and ok=true", next, ok, "c")
-					}
-
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("Cursor() error = %v, want nil", err)
-				}
-			},
-		},
-		{
-			name: "seek missing returns false",
-			run: func(t *testing.T, tree *SyncBST[testEntry]) {
-				err := tree.Cursor(func(c *Cursor[testEntry]) error {
-					got, ok := c.Seek("d")
-					if ok {
-						t.Fatalf("Seek(%q) = (%#v, %v), want ok=false", "d", got, ok)
-					}
-
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("Cursor() error = %v, want nil", err)
-				}
-			},
-		},
-		{
-			name: "prev at beginning returns false",
-			run: func(t *testing.T, tree *SyncBST[testEntry]) {
-				err := tree.Cursor(func(c *Cursor[testEntry]) error {
-					_, _ = c.Seek("a")
-
-					got, ok := c.Prev()
-					if ok {
-						t.Fatalf("Prev() = (%#v, %v), want ok=false", got, ok)
-					}
-
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("Cursor() error = %v, want nil", err)
-				}
-			},
-		},
-		{
-			name: "next at end returns false",
-			run: func(t *testing.T, tree *SyncBST[testEntry]) {
-				err := tree.Cursor(func(c *Cursor[testEntry]) error {
-					_, _ = c.Seek("e")
-
-					got, ok := c.Next()
-					if ok {
-						t.Fatalf("Next() = (%#v, %v), want ok=false", got, ok)
-					}
-
-					return nil
-				})
-				if err != nil {
-					t.Fatalf("Cursor() error = %v, want nil", err)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			tt.run(t, tree)
-		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Cursor() error = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add coverage and docs for `Cursor.First` and `Cursor.Last`, and centralize cursor behavior tests in `cursor_test.go`.

## Changes

- Added table-driven unit tests for `Cursor.First` and `Cursor.Last` in `cursor_test.go`.
- Added GoDoc comments for `Cursor.First` and `Cursor.Last` in `cursor.go`.
- Moved cursor logic coverage (`Seek`, `Prev`, `Next`) from `sync_bst_test.go` into `cursor_test.go`.
- Simplified `TestSyncBSTCursor` to validate `SyncBST.Cursor` provides a non-nil cursor and returns no error.

## Testing

- `go test --race`
