### PR TITLE
Make examples hermetic and independent across BST, Cursor, and SyncBST

### DIFF
--- a/bst_test.go
+++ b/bst_test.go
@@ -5,25 +5,27 @@ import (
 	"log"
 )
 
-var exampleBST BST[testEntry]
-
 func ExampleBST() {
-	exampleBST = make(BST[testEntry], 0, 1024)
+	tree := make(BST[testEntry], 0, 1024)
+
+	_ = tree
+
+	// Output:
 }
 
 func ExampleBST_Insert() {
-	exampleBST.Insert(testEntry{key: "a", value: "alpha"})
-	exampleBST.Insert(testEntry{key: "b", value: "bravo"})
-	exampleBST.Insert(testEntry{key: "c", value: "charlie"})
-	exampleBST.Insert(testEntry{key: "d", value: "delta"})
-	fmt.Printf("exampleBST: %v\n", exampleBST)
+	tree := exampleBSTWithEntries()
+
+	fmt.Printf("exampleBST: %v\n", tree)
 
 	// Output:
 	// exampleBST: [{a alpha} {b bravo} {c charlie} {d delta}]
 }
 
 func ExampleBST_Get() {
-	val, ok := exampleBST.Get("a")
+	tree := exampleBSTWithEntries()
+
+	val, ok := tree.Get("a")
 	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
 
 	// Output:
@@ -31,7 +33,9 @@ func ExampleBST_Get() {
 }
 
 func ExampleBST_ForEach() {
-	if err := exampleBST.ForEach(func(te testEntry) error {
+	tree := exampleBSTWithEntries()
+
+	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleBST.ForEach(): %v\n", te)
 		return nil
 	}); err != nil {
@@ -46,13 +50,28 @@ func ExampleBST_ForEach() {
 }
 
 func ExampleBST_Cursor() {
-	exampleCursor = exampleBST.Cursor()
+	tree := exampleBSTWithEntries()
+
+	_ = tree.Cursor()
+
+	// Output:
 }
 
 func ExampleBST_Remove() {
-	exampleBST.Remove("b")
-	fmt.Printf("exampleBS.Remove(): %v\n", exampleBST)
+	tree := exampleBSTWithEntries()
+
+	tree.Remove("b")
+	fmt.Printf("exampleBS.Remove(): %v\n", tree)
 
 	// Output:
 	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
+}
+
+func exampleBSTWithEntries() (tree BST[testEntry]) {
+	tree = make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	return tree
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 )
 
-var exampleCursor *Cursor[testEntry]
-
 func TestCursorSeek(t *testing.T) {
 	t.Parallel()
 
@@ -269,13 +267,18 @@ func TestCursorLast(t *testing.T) {
 }
 
 func ExampleCursor() {
-	exampleCursor = exampleBST.Cursor()
+	tree := exampleBSTWithEntries()
+
+	_ = tree.Cursor()
 
 	// Output:
 }
 
 func ExampleCursor_Seek() {
-	val, ok := exampleCursor.Seek("d")
+	tree := exampleBSTWithEntries()
+	cursor := tree.Cursor()
+
+	val, ok := cursor.Seek("d")
 	fmt.Printf("cursor.Seek(%q): %v / %v\n", "d", val, ok)
 
 	// Output:
@@ -283,7 +286,11 @@ func ExampleCursor_Seek() {
 }
 
 func ExampleCursor_Prev() {
-	val, ok := exampleCursor.Prev()
+	tree := exampleBSTWithEntries()
+	cursor := tree.Cursor()
+	_, _ = cursor.Seek("d")
+
+	val, ok := cursor.Prev()
 	fmt.Printf("cursor.Prev(): %v / %v\n", val, ok)
 
 	// Output:
@@ -291,7 +298,11 @@ func ExampleCursor_Prev() {
 }
 
 func ExampleCursor_Next() {
-	val, ok := exampleCursor.Next()
+	tree := exampleBSTWithEntries()
+	cursor := tree.Cursor()
+	_, _ = cursor.Seek("c")
+
+	val, ok := cursor.Next()
 	fmt.Printf("cursor.Next(): %v / %v\n", val, ok)
 
 	// Output:
@@ -299,7 +310,10 @@ func ExampleCursor_Next() {
 }
 
 func ExampleCursor_First() {
-	val, ok := exampleCursor.First()
+	tree := exampleBSTWithEntries()
+	cursor := tree.Cursor()
+
+	val, ok := cursor.First()
 	fmt.Printf("cursor.First(): %v / %v\n", val, ok)
 
 	// Output:
@@ -307,7 +321,10 @@ func ExampleCursor_First() {
 }
 
 func ExampleCursor_Last() {
-	val, ok := exampleCursor.Last()
+	tree := exampleBSTWithEntries()
+	cursor := tree.Cursor()
+
+	val, ok := cursor.Last()
 	fmt.Printf("cursor.Last(): %v / %v\n", val, ok)
 
 	// Output:

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 )
 
-var exampleSyncBST *SyncBST[testEntry]
-
 func TestSyncBSTGet(t *testing.T) {
 	t.Parallel()
 
@@ -300,22 +298,28 @@ func TestSyncBSTRemove(t *testing.T) {
 }
 
 func ExampleSyncBST() {
-	exampleSyncBST = NewSync[testEntry](1024)
+	tree := NewSync[testEntry](1024)
+
+	_ = tree
 
 	// Output:
 }
 
 func ExampleSyncBST_Insert() {
-	exampleSyncBST.Insert(testEntry{key: "a", value: "alpha"})
-	exampleSyncBST.Insert(testEntry{key: "b", value: "bravo"})
-	exampleSyncBST.Insert(testEntry{key: "c", value: "charlie"})
-	exampleSyncBST.Insert(testEntry{key: "d", value: "delta"})
+	tree := NewSync[testEntry](1024)
+
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	// Output:
 }
 
 func ExampleSyncBST_Get() {
-	val, ok := exampleSyncBST.Get("a")
+	tree := exampleSyncBSTWithEntries()
+
+	val, ok := tree.Get("a")
 	fmt.Printf("exampleSyncBST.Get(%q): %v / %v\n", "a", val, ok)
 
 	// Output:
@@ -323,7 +327,9 @@ func ExampleSyncBST_Get() {
 }
 
 func ExampleSyncBST_ForEach() {
-	if err := exampleSyncBST.ForEach(func(te testEntry) error {
+	tree := exampleSyncBSTWithEntries()
+
+	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleSyncBST.ForEach(): %v\n", te)
 		return nil
 	}); err != nil {
@@ -338,7 +344,9 @@ func ExampleSyncBST_ForEach() {
 }
 
 func ExampleSyncBST_Cursor() {
-	if err := exampleSyncBST.Cursor(func(cursor *Cursor[testEntry]) error {
+	tree := exampleSyncBSTWithEntries()
+
+	if err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
 		val, ok := cursor.Seek("b")
 		fmt.Printf("cursor.Seek(%q): %v / %v\n", "b", val, ok)
 		return nil
@@ -351,11 +359,23 @@ func ExampleSyncBST_Cursor() {
 }
 
 func ExampleSyncBST_Remove() {
-	exampleSyncBST.Remove("b")
-	fmt.Printf("exampleSyncBST.Length(): %d\n", exampleSyncBST.Length())
+	tree := exampleSyncBSTWithEntries()
+
+	tree.Remove("b")
+	fmt.Printf("exampleSyncBST.Length(): %d\n", tree.Length())
 
 	// Output:
 	// exampleSyncBST.Length(): 3
+}
+
+func exampleSyncBSTWithEntries() (tree *SyncBST[testEntry]) {
+	tree = syncBSTFromEntries(
+		testEntry{key: "a", value: "alpha"},
+		testEntry{key: "b", value: "bravo"},
+		testEntry{key: "c", value: "charlie"},
+		testEntry{key: "d", value: "delta"},
+	)
+	return tree
 }
 
 func syncBSTFromEntries(entries ...testEntry) *SyncBST[testEntry] {


### PR DESCRIPTION
## Summary

- Make all `Example...` tests hermetic by removing cross-example mutable state dependencies.
- Ensure each example can run independently without relying on execution order.

## Changes

- Refactored `ExampleBST...` functions to use local setup through `exampleBSTWithEntries()`.
- Refactored `ExampleCursor...` functions to create local trees/cursors and perform any needed seek/setup inline.
- Refactored `ExampleSyncBST...` functions to initialize local state using `NewSync(...)` and `exampleSyncBSTWithEntries()`.
- Removed global mutable example variables that previously coupled examples together.

## Testing

- `go test --race`