### PR TITLE
Document SyncBST callback lock contract and cleanup cursor release path

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ func ExampleSyncBST_ForEach() {
 }
 ```
 
+`SyncBST.ForEach` runs the callback while `RLock` is held. Do not call `Insert` or `Remove`
+on that same `SyncBST` from inside the callback, or you can self-deadlock.
+
 ### SyncBST.Cursor
 ```go
 func ExampleSyncBST_Cursor() {
@@ -226,6 +229,9 @@ func ExampleSyncBST_Cursor() {
 	})
 }
 ```
+
+`SyncBST.Cursor` runs the callback while `RLock` is held. Do not call `Insert` or `Remove`
+on that same `SyncBST` from inside the callback, or you can self-deadlock.
 
 ### SyncBST.Remove
 ```go
@@ -272,6 +278,10 @@ A cursor can seek to a key, then move to adjacent entries with `Prev` and `Next`
 `BST` is not synchronized.
 
 `SyncBST` provides thread-safe access by wrapping operations with an `RWMutex`.
+
+`SyncBST.ForEach` and `SyncBST.Cursor` hold `RLock` for the entire callback execution.
+Callbacks should be read-only with respect to the same `SyncBST` instance.
+Calling `Insert` or `Remove` from those callbacks can self-deadlock.
 
 ## AI Usage and Authorship
 

--- a/cursor.go
+++ b/cursor.go
@@ -64,3 +64,7 @@ func (c *Cursor[T]) Last() (val T, ok bool) {
 
 	return c.b[c.index], true
 }
+
+func (c *Cursor[T]) cleanup() {
+	c.b = nil
+}

--- a/sync_bst.go
+++ b/sync_bst.go
@@ -2,6 +2,7 @@ package bst
 
 import "sync"
 
+// NewSync creates a SyncBST preallocated with capacity length.
 func NewSync[T Entry](length int) (out *SyncBST[T]) {
 	var s SyncBST[T]
 	s.b = make(BST[T], 0, length)
@@ -22,7 +23,10 @@ func (b *SyncBST[T]) Get(key string) (out T, ok bool) {
 	return b.b.Get(key)
 }
 
-// ForEach calls fn for each entry in key order under a read lock.
+// ForEach calls fn for each entry in key order while holding a read lock.
+//
+// fn executes before the read lock is released. Calling write methods on the
+// same SyncBST instance from fn (for example Insert or Remove) can self-deadlock.
 func (b *SyncBST[T]) ForEach(fn func(T) error) (err error) {
 	b.mux.RLock()
 	defer b.mux.RUnlock()
@@ -30,13 +34,15 @@ func (b *SyncBST[T]) ForEach(fn func(T) error) (err error) {
 }
 
 // Cursor calls fn with a cursor while holding a read lock.
+//
+// fn executes before the read lock is released. Calling write methods on the
+// same SyncBST instance from fn (for example Insert or Remove) can self-deadlock.
 func (b *SyncBST[T]) Cursor(fn func(*Cursor[T]) error) (err error) {
 	b.mux.RLock()
 	defer b.mux.RUnlock()
 	c := b.b.Cursor()
-	err = fn(c)
-	c.b = nil
-	return
+	defer c.cleanup()
+	return fn(c)
 }
 
 // Insert adds val or replaces the existing entry with the same key under a write lock.


### PR DESCRIPTION
## Summary

- Document callback locking behavior for `SyncBST.ForEach` and `SyncBST.Cursor`, including self-deadlock caveats when calling `Insert`/`Remove` from callbacks.
- Improve clarity and hygiene around `SyncBST` cursor lifecycle and constructor documentation.

## Changes

- Added/expanded GoDoc in `sync_bst.go`:
- Added GoDoc for exported constructor `NewSync`.
- Clarified that `ForEach`/`Cursor` callbacks execute while `RLock` is held and that mutating the same `SyncBST` from those callbacks can self-deadlock.
- Updated `SyncBST.Cursor` to use explicit return and deferred cursor cleanup via `c.cleanup()`.
- Added `Cursor.cleanup()` helper in `cursor.go` to encapsulate cursor release.
- Updated `README.md`:
- Added lock-contract warnings under `SyncBST.ForEach` and `SyncBST.Cursor` examples.
- Added concurrency-model note describing callback read-only expectation for the same `SyncBST` instance.

## Testing

- `go test --race`
