### PR TITLE
Improve example clarity and sync README with runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,121 +34,166 @@ then a sorted structure like `bst` can be a better fit.
 ### Initialize BST
 ```go
 func ExampleBST() {
-	users := make(bst.BST[userEntry], 0, 8)
-	_ = users
+	tree := make(BST[testEntry], 0, 1024)
+
+	_ = tree
 }
 ```
 
 ### BST.Insert
 ```go
 func ExampleBST_Insert() {
-	users := make(bst.BST[userEntry], 0, 8)
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "carol"})
-	users.Insert(userEntry{id: 3, name: "bob"})
-	users.Insert(userEntry{id: 4, name: "carol"}) // replaces existing "carol"
+	fmt.Printf("exampleBST: %v\n", tree)
+
+	// Output:
+	// exampleBST: [{a alpha} {b bravo} {c charlie} {d delta}]
 }
 ```
 
 ### BST.Get
 ```go
 func ExampleBST_Get() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	entry, ok := users.Get("alice")
-	fmt.Println(entry.id, ok)
+	val, ok := tree.Get("a")
+	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
+
+	// Output:
+	// exampleBST.Get("a"): {a alpha} / true
 }
 ```
 
 ### BST.ForEach
 ```go
 func ExampleBST_ForEach() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	_ = users.ForEach(func(entry userEntry) error {
-		fmt.Println(entry.name)
+	if err := tree.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleBST.ForEach(): %v\n", te)
 		return nil
-	})
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// exampleBST.ForEach(): {a alpha}
+	// exampleBST.ForEach(): {b bravo}
+	// exampleBST.ForEach(): {c charlie}
+	// exampleBST.ForEach(): {d delta}
 }
 ```
 
 ### BST.Cursor
 ```go
 func ExampleBST_Cursor() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
-	users.Insert(userEntry{id: 3, name: "carol"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	cursor := users.Cursor()
-	_, _ = cursor.Seek("bob")
-	prev, _ := cursor.Prev()
-	next, _ := cursor.Next()
-
-	fmt.Println(prev.name, next.name)
+	_ = tree.Cursor()
 }
 ```
 
 ### BST.Remove
 ```go
 func ExampleBST_Remove() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	users.Remove("alice")
+	tree.Remove("b")
+	fmt.Printf("exampleBS.Remove(): %v\n", tree)
+
+	// Output:
+	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
 }
 ```
 
 ### Cursor.Seek
 ```go
 func ExampleCursor_Seek() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	cursor := tree.Cursor()
 
-	cursor := users.Cursor()
-	entry, ok := cursor.Seek("bob")
-	fmt.Println(entry.id, ok)
+	val, ok := cursor.Seek("d")
+	fmt.Printf("cursor.Seek(%q): %v / %v\n", "d", val, ok)
+
+	// Output:
+	// cursor.Seek("d"): {d delta} / true
 }
 ```
 
 ### Cursor.Prev
 ```go
 func ExampleCursor_Prev() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	cursor := tree.Cursor()
+	_, _ = cursor.Seek("d")
 
-	cursor := users.Cursor()
-	_, _ = cursor.Seek("bob")
-	entry, ok := cursor.Prev()
-	fmt.Println(entry.name, ok)
+	val, ok := cursor.Prev()
+	fmt.Printf("cursor.Prev(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Prev(): {c charlie} / true
 }
 ```
 
 ### Cursor.Next
 ```go
 func ExampleCursor_Next() {
-	users := make(bst.BST[userEntry], 0, 8)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	cursor := tree.Cursor()
+	_, _ = cursor.Seek("c")
 
-	cursor := users.Cursor()
-	_, _ = cursor.Seek("alice")
-	entry, ok := cursor.Next()
-	fmt.Println(entry.name, ok)
+	val, ok := cursor.Next()
+	fmt.Printf("cursor.Next(): %v / %v\n", val, ok)
+
+	// Output:
+	// cursor.Next(): {d delta} / true
 }
 ```
 
 ### Cursor.First
 ```go
 func ExampleCursor_First() {
-	val, ok := exampleCursor.First()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	cursor := tree.Cursor()
+
+	val, ok := cursor.First()
 	fmt.Printf("cursor.First(): %v / %v\n", val, ok)
 
 	// Output:
@@ -159,7 +204,14 @@ func ExampleCursor_First() {
 ### Cursor.Last
 ```go
 func ExampleCursor_Last() {
-	val, ok := exampleCursor.Last()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
+	cursor := tree.Cursor()
+
+	val, ok := cursor.Last()
 	fmt.Printf("cursor.Last(): %v / %v\n", val, ok)
 
 	// Output:
@@ -167,45 +219,65 @@ func ExampleCursor_Last() {
 }
 ```
 
-### NewSync
+### Initialize SyncBST
 ```go
-func ExampleNewSync() {
-	users := bst.NewSync[userEntry](1024)
-	_ = users
+func ExampleSyncBST() {
+	tree := NewSync[testEntry](1024)
+
+	_ = tree
 }
 ```
 
 ### SyncBST.Insert
 ```go
 func ExampleSyncBST_Insert() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := NewSync[testEntry](1024)
+
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 }
 ```
 
 ### SyncBST.Get
 ```go
 func ExampleSyncBST_Get() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	entry, ok := users.Get("alice")
-	fmt.Println(entry.id, ok)
+	val, ok := tree.Get("a")
+	fmt.Printf("exampleSyncBST.Get(%q): %v / %v\n", "a", val, ok)
+
+	// Output:
+	// exampleSyncBST.Get("a"): {a alpha} / true
 }
 ```
 
 ### SyncBST.ForEach
 ```go
 func ExampleSyncBST_ForEach() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	_ = users.ForEach(func(entry userEntry) error {
-		fmt.Println(entry.name)
+	if err := tree.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleSyncBST.ForEach(): %v\n", te)
 		return nil
-	})
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// exampleSyncBST.ForEach(): {a alpha}
+	// exampleSyncBST.ForEach(): {b bravo}
+	// exampleSyncBST.ForEach(): {c charlie}
+	// exampleSyncBST.ForEach(): {d delta}
 }
 ```
 
@@ -215,18 +287,22 @@ on that same `SyncBST` from inside the callback, or you can self-deadlock.
 ### SyncBST.Cursor
 ```go
 func ExampleSyncBST_Cursor() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
-	users.Insert(userEntry{id: 3, name: "carol"})
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-	_ = users.Cursor(func(cursor *bst.Cursor[userEntry]) error {
-		_, _ = cursor.Seek("bob")
-		prev, _ := cursor.Prev()
-		next, _ := cursor.Next()
-		fmt.Println(prev.name, next.name)
+	if err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
+		val, ok := cursor.Seek("b")
+		fmt.Printf("cursor.Seek(%q): %v / %v\n", "b", val, ok)
 		return nil
-	})
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// cursor.Seek("b"): {b bravo} / true
 }
 ```
 
@@ -236,20 +312,17 @@ on that same `SyncBST` from inside the callback, or you can self-deadlock.
 ### SyncBST.Remove
 ```go
 func ExampleSyncBST_Remove() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Remove("alice")
-}
-```
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
-### SyncBST.Length
-```go
-func ExampleSyncBST_Length() {
-	users := bst.NewSync[userEntry](1024)
-	users.Insert(userEntry{id: 1, name: "alice"})
-	users.Insert(userEntry{id: 2, name: "bob"})
+	tree.Remove("b")
+	fmt.Printf("exampleSyncBST.Length(): %d\n", tree.Length())
 
-	fmt.Println(users.Length())
+	// Output:
+	// exampleSyncBST.Length(): 3
 }
 ```
 

--- a/bst_test.go
+++ b/bst_test.go
@@ -14,7 +14,11 @@ func ExampleBST() {
 }
 
 func ExampleBST_Insert() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	fmt.Printf("exampleBST: %v\n", tree)
 
@@ -23,7 +27,11 @@ func ExampleBST_Insert() {
 }
 
 func ExampleBST_Get() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	val, ok := tree.Get("a")
 	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
@@ -33,7 +41,11 @@ func ExampleBST_Get() {
 }
 
 func ExampleBST_ForEach() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleBST.ForEach(): %v\n", te)
@@ -50,7 +62,11 @@ func ExampleBST_ForEach() {
 }
 
 func ExampleBST_Cursor() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	_ = tree.Cursor()
 
@@ -58,20 +74,15 @@ func ExampleBST_Cursor() {
 }
 
 func ExampleBST_Remove() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	tree.Remove("b")
 	fmt.Printf("exampleBS.Remove(): %v\n", tree)
 
 	// Output:
 	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
-}
-
-func exampleBSTWithEntries() (tree BST[testEntry]) {
-	tree = make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
-	return tree
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -267,7 +267,11 @@ func TestCursorLast(t *testing.T) {
 }
 
 func ExampleCursor() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	_ = tree.Cursor()
 
@@ -275,7 +279,11 @@ func ExampleCursor() {
 }
 
 func ExampleCursor_Seek() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.Seek("d")
@@ -286,7 +294,11 @@ func ExampleCursor_Seek() {
 }
 
 func ExampleCursor_Prev() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 	cursor := tree.Cursor()
 	_, _ = cursor.Seek("d")
 
@@ -298,7 +310,11 @@ func ExampleCursor_Prev() {
 }
 
 func ExampleCursor_Next() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 	cursor := tree.Cursor()
 	_, _ = cursor.Seek("c")
 
@@ -310,7 +326,11 @@ func ExampleCursor_Next() {
 }
 
 func ExampleCursor_First() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.First()
@@ -321,7 +341,11 @@ func ExampleCursor_First() {
 }
 
 func ExampleCursor_Last() {
-	tree := exampleBSTWithEntries()
+	tree := make(BST[testEntry], 0, 4)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.Last()

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -317,7 +317,11 @@ func ExampleSyncBST_Insert() {
 }
 
 func ExampleSyncBST_Get() {
-	tree := exampleSyncBSTWithEntries()
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	val, ok := tree.Get("a")
 	fmt.Printf("exampleSyncBST.Get(%q): %v / %v\n", "a", val, ok)
@@ -327,7 +331,11 @@ func ExampleSyncBST_Get() {
 }
 
 func ExampleSyncBST_ForEach() {
-	tree := exampleSyncBSTWithEntries()
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleSyncBST.ForEach(): %v\n", te)
@@ -344,7 +352,11 @@ func ExampleSyncBST_ForEach() {
 }
 
 func ExampleSyncBST_Cursor() {
-	tree := exampleSyncBSTWithEntries()
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	if err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
 		val, ok := cursor.Seek("b")
@@ -359,23 +371,17 @@ func ExampleSyncBST_Cursor() {
 }
 
 func ExampleSyncBST_Remove() {
-	tree := exampleSyncBSTWithEntries()
+	tree := NewSync[testEntry](1024)
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+	tree.Insert(testEntry{key: "b", value: "bravo"})
+	tree.Insert(testEntry{key: "c", value: "charlie"})
+	tree.Insert(testEntry{key: "d", value: "delta"})
 
 	tree.Remove("b")
 	fmt.Printf("exampleSyncBST.Length(): %d\n", tree.Length())
 
 	// Output:
 	// exampleSyncBST.Length(): 3
-}
-
-func exampleSyncBSTWithEntries() (tree *SyncBST[testEntry]) {
-	tree = syncBSTFromEntries(
-		testEntry{key: "a", value: "alpha"},
-		testEntry{key: "b", value: "bravo"},
-		testEntry{key: "c", value: "charlie"},
-		testEntry{key: "d", value: "delta"},
-	)
-	return tree
 }
 
 func syncBSTFromEntries(entries ...testEntry) *SyncBST[testEntry] {


### PR DESCRIPTION
## Summary

- Make BST, Cursor, and SyncBST examples easier to understand by using fully self-contained setup in each example.
- Keep README examples aligned with the actual example tests so docs and executable examples match.

## Changes

- Updated example functions in `bst_test.go`, `cursor_test.go`, and `sync_bst_test.go` to inline tree initialization and seed data instead of relying on shared helper constructors.
- Removed now-unused helper functions `exampleBSTWithEntries` and `exampleSyncBSTWithEntries`.
- Updated `README.md` example snippets to mirror current test examples, including clearer setup and output blocks.
- Renamed the Sync section heading in README from `NewSync` to `Initialize SyncBST` for consistency with the rest of the guide.

## Testing

- `go test --race`
