### PR TITLE
Clarify SyncBST usage and NewSync negative length behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,21 @@ func ExampleSyncBST() {
 }
 ```
 
+`SyncBST` has a usable zero value, so this is also valid:
+
+```go
+func ExampleSyncBST_ZeroValue() {
+	var tree SyncBST[testEntry]
+
+	tree.Insert(testEntry{key: "a", value: "alpha"})
+}
+```
+
+Use a non-nil value for method calls. `var tree *SyncBST[testEntry]` is nil, and
+calling methods on it panics.
+
+`NewSync(length int)` follows Go's `make` behavior: negative `length` panics.
+
 ### SyncBST.Insert
 ```go
 func ExampleSyncBST_Insert() {

--- a/sync_bst.go
+++ b/sync_bst.go
@@ -3,6 +3,9 @@ package bst
 import "sync"
 
 // NewSync creates a SyncBST preallocated with capacity length.
+//
+// length must be >= 0. A negative length panics (same behavior as make with
+// a negative capacity).
 func NewSync[T Entry](length int) (out *SyncBST[T]) {
 	var s SyncBST[T]
 	s.b = make(BST[T], 0, length)
@@ -10,6 +13,12 @@ func NewSync[T Entry](length int) (out *SyncBST[T]) {
 }
 
 // SyncBST wraps a BST with an RWMutex for concurrent access.
+//
+// The zero value is ready to use:
+//
+//	var s SyncBST[T]
+//
+// A nil *SyncBST is not valid. Calling methods on a nil pointer panics.
 type SyncBST[T Entry] struct {
 	mux sync.RWMutex
 


### PR DESCRIPTION
## Summary

- Clarify `SyncBST` usage expectations for zero-value and nil-pointer cases.
- Document `NewSync(length int)` behavior for negative input.

## Changes

- Updated GoDoc in `sync_bst.go`:
  - Documented that `SyncBST` zero value is usable.
  - Documented that calling methods on a nil `*SyncBST` panics.
  - Documented that `NewSync` panics when `length` is negative (matching `make` behavior).
- Updated `README.md`:
  - Added a zero-value `SyncBST` usage example.
  - Added nil-pointer usage warning.
  - Added note about `NewSync` negative-length panic behavior.

## Testing

- N/A