### PR TITLE
Add JSON support for BST/SyncBST with tests and README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,25 @@ func ExampleBST_Remove() {
 }
 ```
 
+### BST.UnmarshalJSON
+
+Inbound JSON entries are sorted by `Key()` during unmarshal before assignment.
+
+```go
+func ExampleBST_UnmarshalJSON() {
+	var tree BST[testEntry]
+
+	if err := json.Unmarshal([]byte(`[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]`), &tree); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("exampleBST.UnmarshalJSON(): %v\n", tree)
+
+	// Output:
+	// exampleBST.UnmarshalJSON(): [{a alpha} {b bravo} {c charlie}]
+}
+```
+
 ### Cursor.Seek
 ```go
 func ExampleCursor_Seek() {
@@ -338,6 +357,50 @@ func ExampleSyncBST_Remove() {
 
 	// Output:
 	// exampleSyncBST.Length(): 3
+}
+```
+
+### SyncBST.MarshalJSON
+```go
+func ExampleSyncBST_MarshalJSON() {
+	tree := NewSync[testEntry](0)
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+
+	bs, err := json.Marshal(tree)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("exampleSyncBST.MarshalJSON(): %s\n", bs)
+
+	// Output:
+	// exampleSyncBST.MarshalJSON(): [{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]
+}
+```
+
+### SyncBST.UnmarshalJSON
+
+Inbound JSON entries are sorted by `Key()` during unmarshal before assignment.
+
+```go
+func ExampleSyncBST_UnmarshalJSON() {
+	var tree SyncBST[testEntry]
+
+	if err := json.Unmarshal([]byte(`[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"}]`), &tree); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tree.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleSyncBST.UnmarshalJSON(): %v\n", te)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// exampleSyncBST.UnmarshalJSON(): {a alpha}
+	// exampleSyncBST.UnmarshalJSON(): {c charlie}
 }
 ```
 

--- a/bst.go
+++ b/bst.go
@@ -1,6 +1,9 @@
 package bst
 
-import "sort"
+import (
+	"encoding/json"
+	"sort"
+)
 
 // BST is a sorted collection of entries keyed by string.
 //
@@ -56,6 +59,21 @@ func (b *BST[T]) Remove(key string) {
 	b.remove(index)
 }
 
+func (b *BST[T]) UnmarshalJSON(bs []byte) (err error) {
+	var s []T
+	if err = json.Unmarshal(bs, &s); err != nil {
+		return err
+	}
+
+	// Ensure that inbound slice is sorted
+	sort.Slice(s, func(i, j int) (less bool) {
+		return s[i].Key() < s[j].Key()
+	})
+
+	*b = s
+	return nil
+}
+
 func (b BST[T]) get(key string) (out T, index int, match bool) {
 	index = sort.Search(len(b), func(i int) bool {
 		return b[i].Key() >= key
@@ -81,6 +99,6 @@ func (b *BST[T]) remove(index int) {
 	*b = (*b)[:len(*b)-1]
 }
 
-func (b *BST[T]) zero() (out T) {
+func (b BST[T]) zero() (out T) {
 	return out
 }

--- a/bst_test.go
+++ b/bst_test.go
@@ -145,3 +145,16 @@ func ExampleBST_Remove() {
 	// Output:
 	// exampleBS.Remove(): [{a alpha} {c charlie} {d delta}]
 }
+
+func ExampleBST_UnmarshalJSON() {
+	var tree BST[testEntry]
+
+	if err := json.Unmarshal([]byte(`[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]`), &tree); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("exampleBST.UnmarshalJSON(): %v\n", tree)
+
+	// Output:
+	// exampleBST.UnmarshalJSON(): [{a alpha} {b bravo} {c charlie}]
+}

--- a/bst_test.go
+++ b/bst_test.go
@@ -1,9 +1,68 @@
 package bst
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"slices"
+	"testing"
 )
+
+func TestBSTUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    []testEntry
+		wantErr bool
+	}{
+		{
+			name:  "sorts inbound entries by key",
+			input: `[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]`,
+			want: []testEntry{
+				{K: "a", V: "alpha"},
+				{K: "b", V: "bravo"},
+				{K: "c", V: "charlie"},
+			},
+		},
+		{
+			name:    "returns error for invalid json",
+			input:   `{"key":"a"`,
+			wantErr: true,
+		},
+		{
+			name:    "returns error for invalid entry type",
+			input:   `[{"key":123,"value":"alpha"}]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tree BST[testEntry]
+			err := json.Unmarshal([]byte(tt.input), &tree)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Unmarshal() error = nil, want non-nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unmarshal() error = %v, want nil", err)
+			}
+
+			if !slices.Equal([]testEntry(tree), tt.want) {
+				t.Fatalf("Unmarshal() = %#v, want %#v", []testEntry(tree), tt.want)
+			}
+		})
+	}
+}
 
 func ExampleBST() {
 	tree := make(BST[testEntry], 0, 1024)
@@ -15,10 +74,10 @@ func ExampleBST() {
 
 func ExampleBST_Insert() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	fmt.Printf("exampleBST: %v\n", tree)
 
@@ -28,10 +87,10 @@ func ExampleBST_Insert() {
 
 func ExampleBST_Get() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	val, ok := tree.Get("a")
 	fmt.Printf("exampleBST.Get(%q): %v / %v\n", "a", val, ok)
@@ -42,10 +101,10 @@ func ExampleBST_Get() {
 
 func ExampleBST_ForEach() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleBST.ForEach(): %v\n", te)
@@ -63,10 +122,10 @@ func ExampleBST_ForEach() {
 
 func ExampleBST_Cursor() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	_ = tree.Cursor()
 
@@ -75,10 +134,10 @@ func ExampleBST_Cursor() {
 
 func ExampleBST_Remove() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	tree.Remove("b")
 	fmt.Printf("exampleBS.Remove(): %v\n", tree)

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -9,9 +9,9 @@ func TestCursorSeek(t *testing.T) {
 	t.Parallel()
 
 	tree := cursorBSTFromEntries(
-		testEntry{key: "a", value: "alpha"},
-		testEntry{key: "c", value: "charlie"},
-		testEntry{key: "e", value: "echo"},
+		testEntry{K: "a", V: "alpha"},
+		testEntry{K: "c", V: "charlie"},
+		testEntry{K: "e", V: "echo"},
 	)
 
 	tests := []struct {
@@ -23,19 +23,19 @@ func TestCursorSeek(t *testing.T) {
 		{
 			name:   "hit",
 			key:    "c",
-			want:   testEntry{key: "c", value: "charlie"},
+			want:   testEntry{K: "c", V: "charlie"},
 			wantOK: true,
 		},
 		{
 			name:   "miss between entries",
 			key:    "d",
-			want:   testEntry{key: "e", value: "echo"},
+			want:   testEntry{K: "e", V: "echo"},
 			wantOK: true,
 		},
 		{
 			name:   "miss before first entry",
 			key:    "0",
-			want:   testEntry{key: "a", value: "alpha"},
+			want:   testEntry{K: "a", V: "alpha"},
 			wantOK: true,
 		},
 		{
@@ -76,7 +76,7 @@ func TestCursorPrev(t *testing.T) {
 		{
 			name:   "returns previous entry",
 			key:    "c",
-			want:   testEntry{key: "a", value: "alpha"},
+			want:   testEntry{K: "a", V: "alpha"},
 			wantOK: true,
 			seekOK: true,
 		},
@@ -94,9 +94,9 @@ func TestCursorPrev(t *testing.T) {
 			t.Parallel()
 
 			tree := cursorBSTFromEntries(
-				testEntry{key: "a", value: "alpha"},
-				testEntry{key: "c", value: "charlie"},
-				testEntry{key: "e", value: "echo"},
+				testEntry{K: "a", V: "alpha"},
+				testEntry{K: "c", V: "charlie"},
+				testEntry{K: "e", V: "echo"},
 			)
 
 			cursor := tree.Cursor()
@@ -130,7 +130,7 @@ func TestCursorNext(t *testing.T) {
 		{
 			name:   "returns next entry",
 			key:    "c",
-			want:   testEntry{key: "e", value: "echo"},
+			want:   testEntry{K: "e", V: "echo"},
 			wantOK: true,
 			seekOK: true,
 		},
@@ -148,9 +148,9 @@ func TestCursorNext(t *testing.T) {
 			t.Parallel()
 
 			tree := cursorBSTFromEntries(
-				testEntry{key: "a", value: "alpha"},
-				testEntry{key: "c", value: "charlie"},
-				testEntry{key: "e", value: "echo"},
+				testEntry{K: "a", V: "alpha"},
+				testEntry{K: "c", V: "charlie"},
+				testEntry{K: "e", V: "echo"},
 			)
 
 			cursor := tree.Cursor()
@@ -190,7 +190,7 @@ func TestCursorPrevAfterSeekMiss(t *testing.T) {
 		{
 			name:     "miss between entries returns lower neighbor",
 			seekKey:  "d",
-			want:     testEntry{key: "c", value: "charlie"},
+			want:     testEntry{K: "c", V: "charlie"},
 			wantOK:   true,
 			wantSeek: true,
 		},
@@ -208,9 +208,9 @@ func TestCursorPrevAfterSeekMiss(t *testing.T) {
 			t.Parallel()
 
 			tree := cursorBSTFromEntries(
-				testEntry{key: "a", value: "alpha"},
-				testEntry{key: "c", value: "charlie"},
-				testEntry{key: "e", value: "echo"},
+				testEntry{K: "a", V: "alpha"},
+				testEntry{K: "c", V: "charlie"},
+				testEntry{K: "e", V: "echo"},
 			)
 
 			cursor := tree.Cursor()
@@ -244,7 +244,7 @@ func TestCursorNextAfterSeekMiss(t *testing.T) {
 		{
 			name:     "miss before first returns second entry",
 			seekKey:  "0",
-			want:     testEntry{key: "c", value: "charlie"},
+			want:     testEntry{K: "c", V: "charlie"},
 			wantOK:   true,
 			wantSeek: true,
 		},
@@ -257,7 +257,7 @@ func TestCursorNextAfterSeekMiss(t *testing.T) {
 		{
 			name:     "miss after last returns false",
 			seekKey:  "z",
-			want:     testEntry{key: "c", value: "charlie"},
+			want:     testEntry{K: "c", V: "charlie"},
 			wantOK:   true,
 			wantSeek: false,
 		},
@@ -269,9 +269,9 @@ func TestCursorNextAfterSeekMiss(t *testing.T) {
 			t.Parallel()
 
 			tree := cursorBSTFromEntries(
-				testEntry{key: "a", value: "alpha"},
-				testEntry{key: "c", value: "charlie"},
-				testEntry{key: "e", value: "echo"},
+				testEntry{K: "a", V: "alpha"},
+				testEntry{K: "c", V: "charlie"},
+				testEntry{K: "e", V: "echo"},
 			)
 
 			cursor := tree.Cursor()
@@ -309,8 +309,8 @@ func TestCursorFirst(t *testing.T) {
 		},
 		{
 			name:    "returns first entry and positions cursor at beginning",
-			tree:    cursorBSTFromEntries(testEntry{key: "a", value: "alpha"}, testEntry{key: "c", value: "charlie"}, testEntry{key: "e", value: "echo"}),
-			want:    testEntry{key: "a", value: "alpha"},
+			tree:    cursorBSTFromEntries(testEntry{K: "a", V: "alpha"}, testEntry{K: "c", V: "charlie"}, testEntry{K: "e", V: "echo"}),
+			want:    testEntry{K: "a", V: "alpha"},
 			wantOK:  true,
 			wantKey: "c",
 		},
@@ -336,7 +336,7 @@ func TestCursorFirst(t *testing.T) {
 			}
 
 			next, nextOK := cursor.Next()
-			if !nextOK || next.key != tt.wantKey {
+			if !nextOK || next.K != tt.wantKey {
 				t.Fatalf("Next() = (%#v, %v), want key %q and ok=true", next, nextOK, tt.wantKey)
 			}
 		})
@@ -360,8 +360,8 @@ func TestCursorLast(t *testing.T) {
 		},
 		{
 			name:    "returns last entry and positions cursor at end",
-			tree:    cursorBSTFromEntries(testEntry{key: "a", value: "alpha"}, testEntry{key: "c", value: "charlie"}, testEntry{key: "e", value: "echo"}),
-			want:    testEntry{key: "e", value: "echo"},
+			tree:    cursorBSTFromEntries(testEntry{K: "a", V: "alpha"}, testEntry{K: "c", V: "charlie"}, testEntry{K: "e", V: "echo"}),
+			want:    testEntry{K: "e", V: "echo"},
 			wantOK:  true,
 			wantKey: "c",
 		},
@@ -387,7 +387,7 @@ func TestCursorLast(t *testing.T) {
 			}
 
 			prev, prevOK := cursor.Prev()
-			if !prevOK || prev.key != tt.wantKey {
+			if !prevOK || prev.K != tt.wantKey {
 				t.Fatalf("Prev() = (%#v, %v), want key %q and ok=true", prev, prevOK, tt.wantKey)
 			}
 		})
@@ -396,10 +396,10 @@ func TestCursorLast(t *testing.T) {
 
 func ExampleCursor() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	_ = tree.Cursor()
 
@@ -408,10 +408,10 @@ func ExampleCursor() {
 
 func ExampleCursor_Seek() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.Seek("d")
@@ -423,10 +423,10 @@ func ExampleCursor_Seek() {
 
 func ExampleCursor_Prev() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 	cursor := tree.Cursor()
 	_, _ = cursor.Seek("d")
 
@@ -439,10 +439,10 @@ func ExampleCursor_Prev() {
 
 func ExampleCursor_Next() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 	cursor := tree.Cursor()
 	_, _ = cursor.Seek("c")
 
@@ -455,10 +455,10 @@ func ExampleCursor_Next() {
 
 func ExampleCursor_First() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.First()
@@ -470,10 +470,10 @@ func ExampleCursor_First() {
 
 func ExampleCursor_Last() {
 	tree := make(BST[testEntry], 0, 4)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 	cursor := tree.Cursor()
 
 	val, ok := cursor.Last()

--- a/sync_bst.go
+++ b/sync_bst.go
@@ -1,6 +1,9 @@
 package bst
 
-import "sync"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // NewSync creates a SyncBST preallocated with capacity length.
 //
@@ -73,4 +76,12 @@ func (b *SyncBST[T]) Length() (n int) {
 	b.mux.RLock()
 	defer b.mux.RUnlock()
 	return len(b.b)
+}
+
+func (b *SyncBST[T]) MarshalJSON() (bs []byte, err error) {
+	return json.Marshal(b.b)
+}
+
+func (b *SyncBST[T]) UnmarshalJSON(bs []byte) (err error) {
+	return json.Unmarshal(bs, &b.b)
 }

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -474,6 +474,41 @@ func ExampleSyncBST_Remove() {
 	// exampleSyncBST.Length(): 3
 }
 
+func ExampleSyncBST_MarshalJSON() {
+	tree := NewSync[testEntry](0)
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+
+	bs, err := json.Marshal(tree)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("exampleSyncBST.MarshalJSON(): %s\n", bs)
+
+	// Output:
+	// exampleSyncBST.MarshalJSON(): [{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]
+}
+
+func ExampleSyncBST_UnmarshalJSON() {
+	var tree SyncBST[testEntry]
+
+	if err := json.Unmarshal([]byte(`[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"}]`), &tree); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tree.ForEach(func(te testEntry) error {
+		fmt.Printf("exampleSyncBST.UnmarshalJSON(): %v\n", te)
+		return nil
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Output:
+	// exampleSyncBST.UnmarshalJSON(): {a alpha}
+	// exampleSyncBST.UnmarshalJSON(): {c charlie}
+}
+
 func syncBSTFromEntries(entries ...testEntry) *SyncBST[testEntry] {
 	tree := &SyncBST[testEntry]{}
 	for _, entry := range entries {

--- a/sync_bst_test.go
+++ b/sync_bst_test.go
@@ -1,6 +1,7 @@
 package bst
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -12,9 +13,9 @@ func TestSyncBSTGet(t *testing.T) {
 	t.Parallel()
 
 	tree := syncBSTFromEntries(
-		testEntry{key: "a", value: "alpha"},
-		testEntry{key: "c", value: "charlie"},
-		testEntry{key: "e", value: "echo"},
+		testEntry{K: "a", V: "alpha"},
+		testEntry{K: "c", V: "charlie"},
+		testEntry{K: "e", V: "echo"},
 	)
 
 	tests := []struct {
@@ -26,7 +27,7 @@ func TestSyncBSTGet(t *testing.T) {
 		{
 			name:   "hit",
 			key:    "c",
-			want:   testEntry{key: "c", value: "charlie"},
+			want:   testEntry{K: "c", V: "charlie"},
 			wantOK: true,
 		},
 		{
@@ -62,9 +63,9 @@ func TestSyncBSTForEach(t *testing.T) {
 	t.Parallel()
 
 	tree := syncBSTFromEntries(
-		testEntry{key: "a", value: "alpha"},
-		testEntry{key: "b", value: "bravo"},
-		testEntry{key: "c", value: "charlie"},
+		testEntry{K: "a", V: "alpha"},
+		testEntry{K: "b", V: "bravo"},
+		testEntry{K: "c", V: "charlie"},
 	)
 
 	sentinel := errors.New("stop")
@@ -85,7 +86,7 @@ func TestSyncBSTForEach(t *testing.T) {
 		{
 			name: "stops on error",
 			fn: func(entry testEntry) error {
-				if entry.key == "b" {
+				if entry.K == "b" {
 					return sentinel
 				}
 
@@ -103,7 +104,7 @@ func TestSyncBSTForEach(t *testing.T) {
 
 			var gotKeys []string
 			err := tree.ForEach(func(entry testEntry) error {
-				gotKeys = append(gotKeys, entry.key)
+				gotKeys = append(gotKeys, entry.K)
 				return tt.fn(entry)
 			})
 
@@ -122,9 +123,9 @@ func TestSyncBSTCursor(t *testing.T) {
 	t.Parallel()
 
 	tree := syncBSTFromEntries(
-		testEntry{key: "a", value: "alpha"},
-		testEntry{key: "c", value: "charlie"},
-		testEntry{key: "e", value: "echo"},
+		testEntry{K: "a", V: "alpha"},
+		testEntry{K: "c", V: "charlie"},
+		testEntry{K: "e", V: "echo"},
 	)
 
 	err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
@@ -150,47 +151,47 @@ func TestSyncBSTInsert(t *testing.T) {
 	}{
 		{
 			name: "insert into empty tree",
-			val:  testEntry{key: "b", value: "bravo"},
+			val:  testEntry{K: "b", V: "bravo"},
 			want: []testEntry{
-				{key: "b", value: "bravo"},
+				{K: "b", V: "bravo"},
 			},
 		},
 		{
 			name: "insert at beginning",
 			tree: []testEntry{
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
-			val: testEntry{key: "a", value: "alpha"},
+			val: testEntry{K: "a", V: "alpha"},
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 		},
 		{
 			name: "insert in middle",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "e", V: "echo"},
 			},
-			val: testEntry{key: "c", value: "charlie"},
+			val: testEntry{K: "c", V: "charlie"},
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 		},
 		{
 			name: "replace existing key",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
 			},
-			val: testEntry{key: "c", value: "updated"},
+			val: testEntry{K: "c", V: "updated"},
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "updated"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "updated"},
 			},
 		},
 	}
@@ -227,52 +228,52 @@ func TestSyncBSTRemove(t *testing.T) {
 		{
 			name: "remove missing key",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
 			},
 			key: "b",
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
 			},
 		},
 		{
 			name: "remove first entry",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 			key: "a",
 			want: []testEntry{
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 		},
 		{
 			name: "remove middle entry",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 			key: "c",
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "e", V: "echo"},
 			},
 		},
 		{
 			name: "remove last entry",
 			tree: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
-				{key: "e", value: "echo"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
+				{K: "e", V: "echo"},
 			},
 			key: "e",
 			want: []testEntry{
-				{key: "a", value: "alpha"},
-				{key: "c", value: "charlie"},
+				{K: "a", V: "alpha"},
+				{K: "c", V: "charlie"},
 			},
 		},
 	}
@@ -297,6 +298,95 @@ func TestSyncBSTRemove(t *testing.T) {
 	}
 }
 
+func TestSyncBSTMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tree := &SyncBST[testEntry]{}
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+
+	bs, err := json.Marshal(tree)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v, want nil", err)
+	}
+
+	var got []testEntry
+	if err = json.Unmarshal(bs, &got); err != nil {
+		t.Fatalf("Unmarshal(marshaled tree) error = %v, want nil", err)
+	}
+
+	want := []testEntry{
+		{K: "a", V: "alpha"},
+		{K: "b", V: "bravo"},
+		{K: "c", V: "charlie"},
+	}
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("Marshal() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSyncBSTUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    []testEntry
+		wantErr bool
+	}{
+		{
+			name:  "sorts inbound entries by key",
+			input: `[{"key":"c","value":"charlie"},{"key":"a","value":"alpha"},{"key":"b","value":"bravo"}]`,
+			want: []testEntry{
+				{K: "a", V: "alpha"},
+				{K: "b", V: "bravo"},
+				{K: "c", V: "charlie"},
+			},
+		},
+		{
+			name:    "returns error for invalid json",
+			input:   `{"key":"a"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var tree SyncBST[testEntry]
+			err := json.Unmarshal([]byte(tt.input), &tree)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Unmarshal() error = nil, want non-nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unmarshal() error = %v, want nil", err)
+			}
+
+			var got []testEntry
+			err = tree.ForEach(func(entry testEntry) error {
+				got = append(got, entry)
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("ForEach() error = %v, want nil", err)
+			}
+
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("Unmarshal() entries = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func ExampleSyncBST() {
 	tree := NewSync[testEntry](1024)
 
@@ -308,20 +398,20 @@ func ExampleSyncBST() {
 func ExampleSyncBST_Insert() {
 	tree := NewSync[testEntry](1024)
 
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	// Output:
 }
 
 func ExampleSyncBST_Get() {
 	tree := NewSync[testEntry](1024)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	val, ok := tree.Get("a")
 	fmt.Printf("exampleSyncBST.Get(%q): %v / %v\n", "a", val, ok)
@@ -332,10 +422,10 @@ func ExampleSyncBST_Get() {
 
 func ExampleSyncBST_ForEach() {
 	tree := NewSync[testEntry](1024)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	if err := tree.ForEach(func(te testEntry) error {
 		fmt.Printf("exampleSyncBST.ForEach(): %v\n", te)
@@ -353,10 +443,10 @@ func ExampleSyncBST_ForEach() {
 
 func ExampleSyncBST_Cursor() {
 	tree := NewSync[testEntry](1024)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	if err := tree.Cursor(func(cursor *Cursor[testEntry]) error {
 		val, ok := cursor.Seek("b")
@@ -372,10 +462,10 @@ func ExampleSyncBST_Cursor() {
 
 func ExampleSyncBST_Remove() {
 	tree := NewSync[testEntry](1024)
-	tree.Insert(testEntry{key: "a", value: "alpha"})
-	tree.Insert(testEntry{key: "b", value: "bravo"})
-	tree.Insert(testEntry{key: "c", value: "charlie"})
-	tree.Insert(testEntry{key: "d", value: "delta"})
+	tree.Insert(testEntry{K: "a", V: "alpha"})
+	tree.Insert(testEntry{K: "b", V: "bravo"})
+	tree.Insert(testEntry{K: "c", V: "charlie"})
+	tree.Insert(testEntry{K: "d", V: "delta"})
 
 	tree.Remove("b")
 	fmt.Printf("exampleSyncBST.Length(): %d\n", tree.Length())
@@ -404,10 +494,10 @@ func collectSyncBST(tree *SyncBST[testEntry]) ([]testEntry, error) {
 }
 
 type testEntry struct {
-	key   string
-	value string
+	K string `json:"key"`
+	V string `json:"value"`
 }
 
 func (e testEntry) Key() string {
-	return e.key
+	return e.K
 }


### PR DESCRIPTION
## Summary

- Add JSON support to `BST` and `SyncBST`.
- Add JSON-focused tests, including error-path coverage and sorting behavior.
- Document JSON usage with executable-style examples in README.

## Changes

- Added `BST.UnmarshalJSON` in `bst.go`:
- Decodes JSON arrays into entries.
- Sorts inbound entries by key before assignment.
- Added `SyncBST.MarshalJSON` and `SyncBST.UnmarshalJSON` in `sync_bst.go`.
- Added/expanded tests:
- `TestBSTUnmarshalJSON` in `bst_test.go` (sorted input behavior, invalid JSON, invalid entry type).
- `TestSyncBSTMarshalJSON` and `TestSyncBSTUnmarshalJSON` in `sync_bst_test.go`.
- Added JSON example functions:
- `ExampleBST_UnmarshalJSON` in `bst_test.go`.
- `ExampleSyncBST_MarshalJSON` and `ExampleSyncBST_UnmarshalJSON` in `sync_bst_test.go`.
- Updated shared test entry fields to `K`/`V` and aligned test usage across `bst_test.go`, `sync_bst_test.go`, and `cursor_test.go`.
- Updated `README.md`:
- Added `BST.UnmarshalJSON`, `SyncBST.MarshalJSON`, and `SyncBST.UnmarshalJSON` example sections.
- Added explicit notes under both unmarshal headers that inbound entries are sorted by key during unmarshal.

## Testing

- `go test --race`
